### PR TITLE
Fix if 'data' variable is a bytes-like object (decode utf-8 string)

### DIFF
--- a/texturecache.py
+++ b/texturecache.py
@@ -1795,6 +1795,8 @@ class MyJSONComms(object):
     decoder = json._default_decoder
     _w=json.decoder.WHITESPACE.match
 
+    if type(data) is bytes:
+        data = data.decode("utf-8")
     idx = _w(data, 0).end()
     end = len(data)
 


### PR DESCRIPTION
When running `./texturecache c` i got this error:

``` python
Traceback (most recent call last):                
  File "./texturecache.py", line 7168, in <module>
    main(sys.argv[1:])
  File "./texturecache.py", line 7011, in main
    extraFields=_extraFields, query=_query)
  File "./texturecache.py", line 3708, in jsonQuery
    lastRun=lastRun, secondaryFields=secondaryFields, uniquecast=UCAST)
  File "./texturecache.py", line 2583, in getData
    self.getDataProxy(mediatype, REQUEST, trim_cast_thumbs=(action != "dump"), uniquecast=uniquecast))
  File "./texturecache.py", line 2596, in getDataProxy
    data = self.chunkedLoad(mediatype, request, trim_cast_thumbs, idname=idname, silent=silent, uniquecast=uniquecast)
  File "./texturecache.py", line 2635, in chunkedLoad
    data = self.sendJSON(request, idname)
  File "./texturecache.py", line 1708, in sendJSON
    for m in self.parseResponse(udata):
  File "./texturecache.py", line 1798, in parseResponse
    idx = _w(data, 0).end()
TypeError: can't use a string pattern on a bytes-like object
```

This commit is fixing the issue.
