### PR TITLE
partially fix #49

### DIFF
--- a/texturecache.py
+++ b/texturecache.py
@@ -108,7 +108,7 @@ class MyConfiguration(object):
     embedded_urls = "^video, ^music"
 
     if MyUtility.isPython3:
-      config = ConfigParser.SafeConfigParser(strict=False)
+      config = ConfigParser.ConfigParser(strict=False)
     else:
       config = ConfigParser.SafeConfigParser()
     self.config = config


### PR DESCRIPTION
This fixes the warning on line 111.  The one on line 149 remains.  I am unsure how to correctly use the suggested: `'parser.read_file()'`